### PR TITLE
FIXED :: bug : Allowing All File Types for Upload in Create Event Popup #43

### DIFF
--- a/src/firebaseConf.ts
+++ b/src/firebaseConf.ts
@@ -15,14 +15,6 @@ import { Zoom, toast } from "react-toastify";
 
 const firebaseConfig = {
   // firebase configuration
-  apiKey: "AIzaSyBEBhBv7AcPhmWS1JwfXijBEarDjsz16xM",
-  authDomain: "lupo-7ba5f.firebaseapp.com",
-  databaseURL: "https://lupo-7ba5f-default-rtdb.firebaseio.com",
-  projectId: "lupo-7ba5f",
-  storageBucket: "lupo-7ba5f.appspot.com",
-  messagingSenderId: "418172032930",
-  appId: "1:418172032930:web:b28842c67139e5c0e6c4fb",
-  measurementId: "G-1NVNFSWR1M",
 };
 const app = firebase.initializeApp(firebaseConfig);
 // Initialize Firebase authentication

--- a/src/firebaseConf.ts
+++ b/src/firebaseConf.ts
@@ -15,6 +15,14 @@ import { Zoom, toast } from "react-toastify";
 
 const firebaseConfig = {
   // firebase configuration
+  apiKey: "AIzaSyBEBhBv7AcPhmWS1JwfXijBEarDjsz16xM",
+  authDomain: "lupo-7ba5f.firebaseapp.com",
+  databaseURL: "https://lupo-7ba5f-default-rtdb.firebaseio.com",
+  projectId: "lupo-7ba5f",
+  storageBucket: "lupo-7ba5f.appspot.com",
+  messagingSenderId: "418172032930",
+  appId: "1:418172032930:web:b28842c67139e5c0e6c4fb",
+  measurementId: "G-1NVNFSWR1M",
 };
 const app = firebase.initializeApp(firebaseConfig);
 // Initialize Firebase authentication


### PR DESCRIPTION
FIXED:: bug : Allowing All File Types for Upload in Create Event Popup #43

 #43

- Updated the handleImageChange function to reset the value of the file input element after displaying an error toast for non-image files.
- Added a line of code (e.target.value = '';) to reset the file input element's value, ensuring that the selected file is cleared from the input field.

![image](https://github.com/Tanay-ErrorCode/lupo-skill/assets/101548649/e770489f-2a67-47af-89d5-c24db2fe734d)
