### PR TITLE
fixed-Toggle Button Doesn't Close Automatically on Navbar Links Click (Mobile View) #97

### DIFF
--- a/src/components/Cards/CreateEvent/CreateEvent.tsx
+++ b/src/components/Cards/CreateEvent/CreateEvent.tsx
@@ -48,7 +48,7 @@ function generateUUID() {
   });
 }
 
-const CreateEvent = ({ props }: any) => {
+const CreateEvent = ({ onNavLinkClick, props }: any) => {
   const [show, setShow] = useState(false);
   const is_signup = localStorage.getItem("userUid") ? true : false;
   const [isSignupModelOpen, setIsSignupModelOpen] = useState(false);
@@ -56,6 +56,10 @@ const CreateEvent = ({ props }: any) => {
   const handleShow = () => {
     if (is_signup) setShow(true);
     else setIsSignupModelOpen(!isSignupModelOpen);
+
+    if (onNavLinkClick) {
+      onNavLinkClick(); // Close the navbar when Create Event is clicked
+    }
   };
 
   const [title, setTitle] = useState("");

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -15,6 +15,7 @@ import Signup from "../Signup/Signup";
 import { toast } from "react-toastify";
 import { signOutUser } from "../../firebaseConf";
 import logo from "../image_assets/logo.png";
+
 const NavBar = () => {
   const [expanded, setExpanded] = useState(false);
   const [show, setShow] = useState(false);
@@ -23,13 +24,19 @@ const NavBar = () => {
     setExpanded(!expanded);
   };
 
+  const handleClose = () => {
+    setExpanded(false); // This will close the navbar
+  };
+
   const userPic = localStorage.getItem("userPic");
   const is_signup = userPic ? true : false;
   const userUid = localStorage.getItem("userUid");
 
   const handleDashboard = () => {
     if (!is_signup) setShow(!show);
+    handleClose(); // Close the navbar when Dashboard is clicked
   };
+
   return (
     <Navbar
       bg="dark"
@@ -60,13 +67,23 @@ const NavBar = () => {
 
         <Navbar.Collapse id="responsive-navbar-nav">
           <Nav className="m-auto align-items-center">
-            <Nav.Link href="#/">Home</Nav.Link>
+            <Nav.Link href="#/" onClick={handleClose}>
+              {" "}
+              {/* Close the navbar when Home is clicked */}
+              Home
+            </Nav.Link>
             <Nav.Link href="#/dashboard" onClick={handleDashboard}>
+              {" "}
+              {/* Close the navbar when Dashboard is clicked */}
               Dashboard
             </Nav.Link>
-            <Nav.Link href="#/events">Events</Nav.Link>
-            {/* /dashboard */}
-            <CreateEvent props={"navbar"} />
+            <Nav.Link href="#/events" onClick={handleClose}>
+              {" "}
+              {/* Close the navbar when Events is clicked */}
+              Events
+            </Nav.Link>
+            <CreateEvent onNavLinkClick={handleClose} />{" "}
+            {/* Pass handleClose to CreateEvent */}
           </Nav>
           <Nav className="align-items-center">
             {!is_signup ? (
@@ -89,6 +106,7 @@ const NavBar = () => {
                   <NavDropdown.Item
                     href={"#/profile/" + (userUid ? userUid : "")}
                     className="text-success  nav-profile-dropdown"
+                    onClick={handleClose} // Close the navbar when View Profile is clicked
                   >
                     View Profile
                   </NavDropdown.Item>
@@ -97,6 +115,7 @@ const NavBar = () => {
                     className="text-danger  nav-profile-dropdown"
                     onClick={() => {
                       signOutUser();
+                      handleClose(); // Close the navbar when Logout is clicked
                     }}
                   >
                     Logout


### PR DESCRIPTION
**What kind of change does this PR introduce?**

In the mobile view of the website, the toggle button on the navbar fails to close automatically upon clicking any of the navbar links. This issue results in an inconvenience for users navigating the site on mobile devices as the navbar remains open, obstructing the view of the content.

So I have fixed this issue by making a new function to handle link clicks and close the menu as -
```
 const handleClose = () => {
    setExpanded(false);  // This will close the navbar
  };
```

And for Create Event link item in navbar, I make following modification-

- In `NavBar.tsx`, we pass` handleClose` as a prop to `CreateEvent`.
- In `CreateEvent.tsx`, we define `onNavLinkClick` prop and call it inside` handleShow` to ensure the navbar closes when the "Create Event" link is clicked.


**Issue Number:**

Fixes #97 

**Snapshots/Videos:**

Screenshot with issues -
![332926971-af6539d2-8ce5-45e5-9649-891cbadb8542](https://github.com/Tanay-ErrorCode/lupo-skill/assets/115466381/6efe3aad-0917-4933-a1b2-3815a25467a7)


Screenshot of fixed issues -
![image](https://github.com/Tanay-ErrorCode/lupo-skill/assets/115466381/dd61afb8-a9d0-4a72-a985-335128dcb3fe)

**Other information**

- [ X] I have performed a self-review of my code
- [ X] I have read and followed the Contribution Guidelines.
- [ X] I have tested the changes thoroughly before submitting this pull request.
- [X ] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X ] I have commented my code, particularly in hard-to-understand areas.
