### PR TITLE
Added github repository link to 'Star on github' button

### DIFF
--- a/src/components/HomePage/HomePage.tsx
+++ b/src/components/HomePage/HomePage.tsx
@@ -301,6 +301,10 @@ const HomePage = () => {
                 >
                   Give us a star! ⭐
                 </Typography>
+                <Link
+                  to={"https://github.com/Tanay-ErrorCode/lupo-skill"}
+                  style={{ textDecoration: "none" }}
+                >
                 <CustomButton
                   icon={<GitHubIcon />}
                   text="Star on GitHub"
@@ -309,6 +313,7 @@ const HomePage = () => {
                   onClick={() => console.log("Get Started")}
                   borderColor={theme.colors.secondaryLight}
                 />
+                </Link>
               </Grid>
               <Grid
                 item


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Added github repository link to the 'Star on github' button.
<!-- add detailed explanation -->
On clicking on the `Star on github` button it is not redirecting to the github account. I resolved that issue.

**Issue Number:**

Fixes  bug #70
**Snapshots/Videos:**

[Screenshot 2024-05-24 132122](https://github.com/Tanay-ErrorCode/lupo-skill/assets/124513264/ff812028-b242-404f-b58f-9bd226e0d296)



