### PR TITLE
bug : White Space Appears When Scrolling Right on Mobile View (Homepage) #184

### DIFF
--- a/src/components/HomePage/HomePage.tsx
+++ b/src/components/HomePage/HomePage.tsx
@@ -99,6 +99,7 @@ const HomePage = () => {
       style={{
         paddingTop: "6.5em",
         height: "100%",
+        overflow: "hidden",
         background:
           "radial-gradient(circle, rgb(1 126 172 / 83%) 0%, rgb(27, 79, 105) 40%, rgb(0, 0, 0) 80%)",
         // "radial-gradient(circle,navy 0%, seagreen 50%, rgba(0, 0, 0, 1) 90%)",


### PR DESCRIPTION
bug : White Space Appears When Scrolling Right on Mobile View (Homepage) #184

#184 

![Screenshot 2024-06-06 151530](https://github.com/Tanay-ErrorCode/lupo-skill/assets/101548649/e944c569-86fc-4b3e-a0aa-fd8d35e0b2b3)
