### PR TITLE
Added hover effect on "star on GitHub" and "contribute Now" button on homepage

### DIFF
--- a/src/components/Button/Button.css
+++ b/src/components/Button/Button.css
@@ -1,9 +1,3 @@
-.multi-color-border {
-  transition: transform 1s ease, opacity 1s ease !important;
-  padding: 3px;
-  border-radius: 18px;
-}
-
 .static-border {
   padding: 3px;
 }
@@ -12,29 +6,63 @@
   border: none !important;
 }
 
-.multi-color-border:hover {
-  transform: scale(1.03);
-  background: conic-gradient(
-    from var(--a),
-    rgb(219, 208, 2) 20%,
-    rgb(0, 172, 249) 50%,
-    rgb(219, 208, 2) 100%
+.multi-color-border {
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  transition: transform 1s ease, opacity 1s ease !important;
+  padding: 4px;
+  border-radius: 18px;
+  background: linear-gradient(
+    290.7deg,
+    rgb(255, 242, 0),
+    rgb(0, 172, 249) 100.2%
   );
-  animation: animate 10s linear infinite;
+  align-items: center;
+  justify-content: center;
 }
 
-@property --a {
-  syntax: "<angle>";
-  inherits: false;
-  initial-value: 0deg;
+.multi-color-border::before {
+  content: "";
+  position: absolute;
+  top: -20%;
+  right: -10%;
+  bottom: -20%;
+  left: -20%;
+  width: 500%;
+  height: 400%;
+  background: linear-gradient(
+    290.7deg,
+    rgb(255, 242, 0),
+    rgb(0, 172, 249) 100.2%
+  );
+  transition: opacity 0.3s ease-in-out;
+  opacity: 0;
+  z-index: 0;
+  inset: -8rem -8rem;
 }
 
-@keyframes animate {
+.multi-color-border:hover {
+  transform: scale(1.07);
+}
+
+.multi-color-border:hover::before {
+  background: linear-gradient(
+    290.7deg,
+    rgb(255, 242, 0),
+    rgb(0, 172, 249) 100.2%
+  );
+  transition: opacity 0.3s ease-in-out;
+  opacity: 1;
+  animation: rotateGradient 2s linear infinite;
+}
+
+@keyframes rotateGradient {
   0% {
-    --a: 0deg;
+    transform: rotate(0deg);
   }
 
   100% {
-    --a: 360deg;
+    transform: rotate(360deg);
   }
 }

--- a/src/components/Button/Button.css
+++ b/src/components/Button/Button.css
@@ -1,0 +1,36 @@
+.multi-color-border {
+  transition: transform 1s ease, opacity 1s ease !important;
+  padding: 3px;
+  border-radius: 18px;
+}
+
+.static-border {
+  padding: 3px;
+}
+
+.multi-color-border:hover {
+  transform: scale(1.02);
+  background: repeating-conic-gradient(
+    from var(--a),
+    rgb(255, 242, 0) 30%,
+    rgb(255, 242, 0) 40%,
+    rgb(0, 172, 249) 70%
+  );
+  animation: animate 1.5s linear infinite;
+}
+
+@property --a {
+  syntax: "<angle>";
+  inherits: false;
+  initial-value: 0deg;
+}
+
+@keyframes animate {
+  0% {
+    --a: 0deg;
+  }
+
+  100% {
+    --a: 360deg;
+  }
+}

--- a/src/components/Button/Button.css
+++ b/src/components/Button/Button.css
@@ -8,15 +8,19 @@
   padding: 3px;
 }
 
+.custom-button:hover {
+  border: none !important;
+}
+
 .multi-color-border:hover {
-  transform: scale(1.02);
-  background: repeating-conic-gradient(
+  transform: scale(1.03);
+  background: conic-gradient(
     from var(--a),
-    rgb(255, 242, 0) 30%,
-    rgb(255, 242, 0) 40%,
-    rgb(0, 172, 249) 70%
+    rgb(219, 208, 2) 20%,
+    rgb(0, 172, 249) 50%,
+    rgb(219, 208, 2) 100%
   );
-  animation: animate 1.5s linear infinite;
+  animation: animate 10s linear infinite;
 }
 
 @property --a {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -81,6 +81,7 @@ const CustomButton: React.FC<CustomButtonProps> = ({
         onClick={onClick}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
+        className="custom-button"
       >
         {text}
       </Button>

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import Button from "@mui/material/Button";
 import PropTypes from "prop-types";
 import theme from "../../theme";
+import "./Button.css";
 
 interface CustomButtonProps {
   text: string;
@@ -12,6 +13,7 @@ interface CustomButtonProps {
   onClick?: () => void;
   hoverColor?: string;
   colorChange?: boolean;
+  borderStyleChange?: boolean;
 }
 
 const CustomButton: React.FC<CustomButtonProps> = ({
@@ -23,10 +25,12 @@ const CustomButton: React.FC<CustomButtonProps> = ({
   onClick,
   hoverColor,
   colorChange,
+  borderStyleChange,
 }) => {
   const colorList = ["#FFC0D9", theme.colors.secondaryLight];
   const [currentBackgroundColorIndex, setCurrentBackgroundColorIndex] =
     useState(0);
+  const [isNewBorderStyleActive, setNewBorderStyleActive] = useState(false);
 
   const handleMouseEnter = () => {
     if (colorChange && colorList && colorList.length > 0) {
@@ -34,11 +38,17 @@ const CustomButton: React.FC<CustomButtonProps> = ({
         (prevIndex) => (prevIndex + 1) % colorList.length
       );
     }
+    if (borderStyleChange) {
+      setNewBorderStyleActive(!isNewBorderStyleActive);
+    }
   };
 
   const handleMouseLeave = () => {
     if (colorChange && colorList && colorList.length > 0) {
       setCurrentBackgroundColorIndex(0);
+    }
+    if (borderStyleChange) {
+      setNewBorderStyleActive(!isNewBorderStyleActive);
     }
   };
 
@@ -47,28 +57,34 @@ const CustomButton: React.FC<CustomButtonProps> = ({
     : backgroundColor;
 
   return (
-    <Button
-      variant="contained"
-      style={{
-        textTransform: "none",
-        fontSize: "1rem",
-        border: "2px solid",
-        fontWeight: "bold",
-        width: "fit-content",
-        borderRadius: "16px",
-        borderColor: borderColor || "black",
-        backgroundColor: currentBackgroundColor,
-        padding: "8px 24px",
-        color: textColor || "black",
-        transition: "background-color 0.3s", // Add transition for smooth color change
-      }}
-      startIcon={icon}
-      onClick={onClick}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
+    <div
+      className={
+        isNewBorderStyleActive ? "multi-color-border" : "static-border"
+      }
     >
-      {text}
-    </Button>
+      <Button
+        variant="contained"
+        style={{
+          textTransform: "none",
+          fontSize: "1rem",
+          border: "2px solid",
+          fontWeight: "bold",
+          width: "fit-content",
+          borderRadius: "16px",
+          borderColor: borderColor || "black",
+          backgroundColor: currentBackgroundColor,
+          padding: "8px 24px",
+          color: textColor || "black",
+          transition: "background-color 0.3s", // Add transition for smooth color change
+        }}
+        startIcon={icon}
+        onClick={onClick}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+      >
+        {text}
+      </Button>
+    </div>
   );
 };
 
@@ -81,6 +97,7 @@ CustomButton.propTypes = {
   onClick: PropTypes.func,
   hoverColor: PropTypes.string, // Add prop type for hoverColor
   colorChange: PropTypes.bool,
+  borderStyleChange: PropTypes.bool,
 };
 
 export default CustomButton;

--- a/src/components/HomePage/HomePage.tsx
+++ b/src/components/HomePage/HomePage.tsx
@@ -567,6 +567,8 @@ const HomePage = () => {
                       textColor={theme.colors.brightBackground}
                       onClick={() => console.log("Get Started")}
                       borderColor={theme.colors.secondaryLight}
+                      colorChange={true}
+                      borderStyleChange={true}
                     />
                   </Link>
                 </motion.div>
@@ -613,6 +615,8 @@ const HomePage = () => {
                       textColor={theme.colors.brightBackground}
                       onClick={() => console.log("Get Started")}
                       borderColor={theme.colors.secondaryLight}
+                      colorChange={true}
+                      borderStyleChange={true}
                     />
                   </Link>
                 </motion.div>

--- a/src/components/HomePage/HomePage.tsx
+++ b/src/components/HomePage/HomePage.tsx
@@ -567,7 +567,7 @@ const HomePage = () => {
                       textColor={theme.colors.brightBackground}
                       onClick={() => console.log("Get Started")}
                       borderColor={theme.colors.secondaryLight}
-                      colorChange={true}
+                      // colorChange={true}
                       borderStyleChange={true}
                     />
                   </Link>
@@ -615,7 +615,7 @@ const HomePage = () => {
                       textColor={theme.colors.brightBackground}
                       onClick={() => console.log("Get Started")}
                       borderColor={theme.colors.secondaryLight}
-                      colorChange={true}
+                      // colorChange={true}
                       borderStyleChange={true}
                     />
                   </Link>


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Hover Effect are added to the start on github and contribute now button on the homepage similar to as of Template card hover. It's done by adding borderStyleChange prop to custom button and a class to style the border on button component which toggles as per mouseEnter and mouseLeave event, A new button.css is applied to make animated border style.

**Issue Number:**
#224 

Fixes #224 
**Snapshots:**
Before Hover
![image](https://github.com/Tanay-ErrorCode/lupo-skill/assets/92215187/4d6b4154-0620-4ecc-8325-67b274f2d51d)


After Hover
<img width="462" alt="image" src="https://github.com/Tanay-ErrorCode/lupo-skill/assets/92215187/5128adaa-7864-418d-95ea-b4c9e3cdd365">

Similar effect is added on contribute now button as well!
